### PR TITLE
違う secret_key で暗号化されたデータを設定する場合、バリデーションエラーが発生すると保存できない問題

### DIFF
--- a/lib/field_encryptable.rb
+++ b/lib/field_encryptable.rb
@@ -112,6 +112,7 @@ module FieldEncryptable
           plaintext_loaded!(attr)
           instance_variable_get("@#{attr}")
         rescue
+          plaintext_loaded!(attr)
           nil
         end
       end

--- a/lib/field_encryptable.rb
+++ b/lib/field_encryptable.rb
@@ -107,12 +107,15 @@ module FieldEncryptable
             instance_variable_set("@#{attr}", read_attribute("encrypted_#{attr}"))
             require_encription!(attr)
           else
-            instance_variable_set("@#{attr}", encryptor.decrypt_and_verify(read_attribute("encrypted_#{attr}")))
+            instance_variable_set "@#{attr}", begin
+              encryptor.decrypt_and_verify(read_attribute("encrypted_#{attr}"))
+            rescue
+              nil
+            end
           end
           plaintext_loaded!(attr)
           instance_variable_get("@#{attr}")
         rescue
-          plaintext_loaded!(attr)
           nil
         end
       end

--- a/lib/field_encryptable.rb
+++ b/lib/field_encryptable.rb
@@ -100,24 +100,20 @@ module FieldEncryptable
 
     def define_encrypted_attribute_methods(attr, type = :string)
       define_method("decrypt_#{attr}") do
-        begin
-          return instance_variable_get("@#{attr}") if plaintext_loaded?(attr)
+        return instance_variable_get("@#{attr}") if plaintext_loaded?(attr)
 
-          if new_record?
-            instance_variable_set("@#{attr}", read_attribute("encrypted_#{attr}"))
-            require_encription!(attr)
-          else
-            instance_variable_set "@#{attr}", begin
-              encryptor.decrypt_and_verify(read_attribute("encrypted_#{attr}"))
-            rescue
-              nil
-            end
+        if new_record?
+          instance_variable_set("@#{attr}", read_attribute("encrypted_#{attr}"))
+          require_encription!(attr)
+        else
+          instance_variable_set "@#{attr}", begin
+            encryptor.decrypt_and_verify(read_attribute("encrypted_#{attr}"))
+          rescue
+            nil
           end
-          plaintext_loaded!(attr)
-          instance_variable_get("@#{attr}")
-        rescue
-          nil
         end
+        plaintext_loaded!(attr)
+        instance_variable_get("@#{attr}")
       end
 
       define_method("#{attr}_was") do


### PR DESCRIPTION
違う secret_key で暗号化されたデータを読み込む場合(= 例外が発生する場合) バリデーションが設定されている場合、バリデーションエラーになる。
そのため、再設定した値を保存ができないため修正しました。