### PR TITLE
lib: rails5.2 に上げる際の修正

### DIFF
--- a/lib/field_encryptable.rb
+++ b/lib/field_encryptable.rb
@@ -72,7 +72,7 @@ module FieldEncryptable
     attr_reader :encryptor
 
     def encrypt_key(key)
-      @encryptor = ActiveSupport::MessageEncryptor.new(key.to_s)
+      @encryptor = ActiveSupport::MessageEncryptor.new(key.to_s[0..31], key.to_s)
     end
 
     def encrypt_fields(*attributes)


### PR DESCRIPTION
https://qiita.com/rentalname@github/items/05eaf0afd9b8acf8f26d
* ruby のバージョンアップに伴い、key が 32 bytes である必要がある
* バージョンアップした際、古いデータの複合ができるように対応する必要がある。

https://github.com/rails/rails/issues/28401
https://github.com/rails/rails/blob/4-2-stable/activesupport/test/message_encryptor_test.rb#L58-L66
を参考に修正を行いました。