### PR TITLE
Fix instantiation timing

### DIFF
--- a/lib/field_encryptable.rb
+++ b/lib/field_encryptable.rb
@@ -69,10 +69,14 @@ module FieldEncryptable
 
   module ClassMethods
     attr_accessor :encrypt_target_columns
-    attr_reader :encryptor
 
     def encrypt_key(key)
-      @encryptor = ActiveSupport::MessageEncryptor.new(key.to_s[0..31], key.to_s)
+      @key = key.to_s
+    end
+
+    def encryptor
+      return if @key.blank?
+      @encryptor ||= ActiveSupport::MessageEncryptor.new(@key[0..31], @key)
     end
 
     def encrypt_fields(*attributes)

--- a/lib/field_encryptable/version.rb
+++ b/lib/field_encryptable/version.rb
@@ -1,3 +1,3 @@
 module FieldEncryptable
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
クラスロード時点で `ActiveSupport::MessageEncryptor.new` をしてしまうと、 Rails の `Rails.application.config.active_support.use_authenticated_message_encryption` オプションが反映される前に作成されてしまい、暗号化方式に設定値が反映されないことがある問題の修正。